### PR TITLE
Move long running requests to background task

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -15,3 +15,6 @@ class CecilConstants:
     HASHING_ALGORITHM = "HS256"
     WL_PATH = "./watchlists"
     CONFIG_PATH = "./config.json"
+    MESSAGE_PROCESSING_IN_BACKGROUND = {
+        "message": "Processing request in the background"
+    }


### PR DESCRIPTION
Closes #54 

These requests were taking >500ms to execute and return no data, so they are moved to the background.